### PR TITLE
Rename `ToastLoggerBuilder::init_logger()` to `init()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The following example shows a toast notification saying "Hello, world".
 ```rust
 ToastLogger::builder()
     .max_level(log::LevelFilter::Info)
-    .init_logger()?;
+    .init()?;
 log::info!("Hello, world");
 ```
 

--- a/examples/auto_flush.rs
+++ b/examples/auto_flush.rs
@@ -6,7 +6,7 @@ pub fn main() -> anyhow::Result<()> {
     ToastLogger::builder()
         .max_level(log::LevelFilter::Info)
         .auto_flush(false)
-        .init_logger()?;
+        .init()?;
 
     for arg in env::args().skip(1) {
         log::info!("{}", arg);

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -5,7 +5,7 @@ use toast_logger_win::ToastLogger;
 pub fn main() -> anyhow::Result<()> {
     ToastLogger::builder()
         .max_level(log::LevelFilter::Info)
-        .init_logger()?;
+        .init()?;
 
     let args: Vec<String> = env::args().skip(1).collect();
     log::info!("{}", args.join("\n"));

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -5,7 +5,7 @@ use toast_logger_win::ToastLogger;
 pub fn main() -> anyhow::Result<()> {
     ToastLogger::builder()
         .max_level(log::LevelFilter::Info)
-        .init_logger()?;
+        .init()?;
 
     for arg in env::args().skip(1) {
         log::info!("{}", arg);

--- a/src/toast_logger.rs
+++ b/src/toast_logger.rs
@@ -58,21 +58,29 @@ impl ToastLoggerBuilder {
     /// ```no_run
     /// # use toast_logger_win::ToastLogger;
     /// # fn test() -> anyhow::Result<()> {
-    /// ToastLogger::builder().init_logger()?;
+    /// ToastLogger::builder().init()?;
     /// # Ok(())
     /// # }
     /// ```
-    pub fn init_logger(&mut self) -> anyhow::Result<()> {
+    pub fn init(&mut self) -> anyhow::Result<()> {
         ToastLogger::init(self.build_config())
+    }
+
+    #[deprecated(since = "0.2.0", note = "Use `init()` instead")]
+    pub fn init_logger(&mut self) -> anyhow::Result<()> {
+        self.init()
+    }
+
+    /// Build a `ToastLogger`.
+    ///
+    /// The returned logger implements the [`Log`] trait
+    /// and can be installed manually or nested within another logger.
+    pub fn build(&mut self) -> anyhow::Result<ToastLogger> {
+        ToastLogger::new(self.build_config())
     }
 
     fn build_config(&mut self) -> ToastLoggerConfig {
         mem::take(&mut self.config)
-    }
-
-    #[cfg(test)]
-    fn build_logger(&mut self) -> anyhow::Result<ToastLogger> {
-        ToastLogger::new(self.build_config())
     }
 
     /// Set the maximum level of logs to be displayed.
@@ -98,7 +106,7 @@ impl ToastLoggerBuilder {
     /// ToastLogger::builder()
     ///     .max_level(log::LevelFilter::Info)
     ///     .auto_flush(false)
-    ///     .init_logger()?;
+    ///     .init()?;
     /// log::info!("Test info log");
     /// log::info!("Test info log 2");
     /// ToastLogger::flush()?;  // Shows only one notification with both logs.
@@ -140,7 +148,7 @@ impl ToastLoggerBuilder {
     ///             _ => write!(buf, "{}: {}", record.level(), record.args()),
     ///         }
     ///     })
-    ///     .init_logger()?;
+    ///     .init()?;
     /// # Ok(())
     /// # }
     /// ```
@@ -161,7 +169,7 @@ impl ToastLoggerBuilder {
 /// # pub fn test() -> anyhow::Result<()> {
 ///   ToastLogger::builder()
 ///       .max_level(log::LevelFilter::Info)
-///       .init_logger()?;
+///       .init()?;
 ///   log::info!("Test info log");  // Shows a Windows Toast Notification.
 /// #  Ok(())
 /// # }
@@ -293,7 +301,7 @@ mod tests {
         let logger = ToastLogger::builder()
             .max_level(log::LevelFilter::Info)
             .auto_flush(false)
-            .build_logger()?;
+            .build()?;
         let info = log::Record::builder()
             .level(log::Level::Info)
             .args(format_args!("test"))


### PR DESCRIPTION
For the simplicity, and match `env_logger`.

Also add the `build()`.
