### PR TITLE
Make `Notifier` non-public

### DIFF
--- a/src/notification.rs
+++ b/src/notification.rs
@@ -58,7 +58,7 @@ impl Notification {
 }
 
 /// Abstracted notifier for the `Notification`.
-pub struct Notifier {
+pub(crate) struct Notifier {
     #[cfg(not(feature = "winrt-toast"))]
     inner: crate::win::ToastNotifier,
     #[cfg(feature = "winrt-toast")]


### PR DESCRIPTION
While `Notification` is required to be public, `Notifier`
isn't necessary.
