### PR TITLE
Use `thiserror` crate for custom error types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,7 +246,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -254,6 +263,17 @@ name = "thiserror-impl"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -272,10 +292,11 @@ dependencies = [
 
 [[package]]
 name = "toast-logger-win"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "log",
+ "thiserror 2.0.12",
  "windows 0.61.1",
  "winrt-toast",
 ]
@@ -464,7 +485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5e118cc630cbeae41334e1760673082fe40840084714ea5c6bd7461080434c4"
 dependencies = [
  "scopeguard",
- "thiserror",
+ "thiserror 1.0.69",
  "url",
  "windows 0.39.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "toast-logger-win"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors = ["Koji Ishii <kojiishi@gmail.com>"]
 description = "Rust's `log` crate logger that sends logging output to the Windows Toast Notifications."
@@ -13,6 +13,7 @@ exclude = [".github", ".gitignore", "hooks", ".vscode"]
 [dependencies]
 anyhow = "1.0.98"
 log = { version = "0.4.27", features = ["std"] }
+thiserror = "2.0.12"
 winrt-toast = { version = "0.1.1", optional = true }
 
 [dependencies.windows]

--- a/examples/auto_flush.rs
+++ b/examples/auto_flush.rs
@@ -1,8 +1,8 @@
 use std::env;
 
-use toast_logger_win::ToastLogger;
+use toast_logger_win::{Result, ToastLogger};
 
-pub fn main() -> anyhow::Result<()> {
+pub fn main() -> Result<()> {
     ToastLogger::builder()
         .max_level(log::LevelFilter::Info)
         .auto_flush(false)

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -1,8 +1,8 @@
 use std::env;
 
-use toast_logger_win::ToastLogger;
+use toast_logger_win::{Result, ToastLogger};
 
-pub fn main() -> anyhow::Result<()> {
+pub fn main() -> Result<()> {
     ToastLogger::builder()
         .max_level(log::LevelFilter::Info)
         .init()?;

--- a/examples/multi.rs
+++ b/examples/multi.rs
@@ -1,8 +1,8 @@
 use std::env;
 
-use toast_logger_win::ToastLogger;
+use toast_logger_win::{Result, ToastLogger};
 
-pub fn main() -> anyhow::Result<()> {
+pub fn main() -> Result<()> {
     ToastLogger::builder()
         .max_level(log::LevelFilter::Info)
         .init()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,8 @@
 //!
 //! The following example shows a toast notification saying "Hello, world".
 //! ```no_run
-//! # use toast_logger_win::ToastLogger;
-//! # fn test() -> anyhow::Result<()> {
+//! # use toast_logger_win::{Result, ToastLogger};
+//! # fn test() -> Result<()> {
 //! ToastLogger::builder()
 //!     .max_level(log::LevelFilter::Error)
 //!     .init()?;
@@ -35,3 +35,25 @@ pub use notification::*;
 
 mod toast_logger;
 pub use toast_logger::*;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error(transparent)]
+    Format(#[from] std::fmt::Error),
+
+    #[error("ToastLogger not initialized")]
+    NotInitialized,
+
+    #[error(transparent)]
+    SetLogger(#[from] log::SetLoggerError),
+
+    #[cfg(not(feature = "winrt-toast"))]
+    #[error("Windows Error: {0}")]
+    Windows(#[from] windows::core::Error),
+
+    #[cfg(feature = "winrt-toast")]
+    #[error("winrt_toast Error: {0}")]
+    WinToast(#[from] winrt_toast::WinToastError),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -1,4 +1,4 @@
-use anyhow::Ok;
+use crate::Result;
 
 #[cfg(doc)]
 use crate::ToastLoggerBuilder;
@@ -57,7 +57,7 @@ pub struct Notification {
 
 impl Notification {
     /// Construct from a string.
-    pub fn new_with_text(text: &str) -> anyhow::Result<Self> {
+    pub fn new_with_text(text: &str) -> Result<Self> {
         Ok(Self {
             #[cfg(not(feature = "winrt-toast"))]
             inner: crate::win::NotificationImpl::new_with_text(text)?,
@@ -71,7 +71,7 @@ impl Notification {
     }
 
     /// Construct from a list of [`BufferedRecord`].
-    pub fn new_with_records(records: &[BufferedRecord]) -> anyhow::Result<Self> {
+    pub fn new_with_records(records: &[BufferedRecord]) -> Result<Self> {
         let text = records
             .iter()
             .map(|r| r.args.as_str())
@@ -84,7 +84,7 @@ impl Notification {
     /// Please see [`ToastNotification.ExpirationTime`].
     ///
     /// [`ToastNotification.ExpirationTime`]: https://learn.microsoft.com/uwp/api/windows.ui.notifications.toastnotification.expirationtime
-    pub fn expires_in(&mut self, duration: std::time::Duration) -> anyhow::Result<()> {
+    pub fn expires_in(&mut self, duration: std::time::Duration) -> Result<()> {
         #[cfg(not(feature = "winrt-toast"))]
         self.inner.expires_in(duration)?;
         #[cfg(feature = "winrt-toast")]
@@ -118,7 +118,7 @@ pub(crate) struct Notifier {
 }
 
 impl Notifier {
-    pub fn new_with_application_id(application_id: &str) -> anyhow::Result<Self> {
+    pub fn new_with_application_id(application_id: &str) -> Result<Self> {
         Ok(Self {
             #[cfg(not(feature = "winrt-toast"))]
             inner: crate::win::NotifierImpl::new_with_application_id(application_id)?,
@@ -127,7 +127,7 @@ impl Notifier {
         })
     }
 
-    pub fn show(&self, notification: &Notification) -> anyhow::Result<()> {
+    pub fn show(&self, notification: &Notification) -> Result<()> {
         self.inner.show(&notification.inner)?;
         Ok(())
     }

--- a/src/win.rs
+++ b/src/win.rs
@@ -13,6 +13,8 @@ use windows::{
     core::{IInspectable, Interface},
 };
 
+use crate::Result;
+
 /// Represents a Toast Notification.
 ///
 /// A thin wrapper for the [`windows::UI::Notifications::ToastNotification`].
@@ -31,12 +33,12 @@ impl NotificationImpl {
     // # Examples
     // ```
     // # use toast_logger_win::win::{ToastNotification, ToastNotifier};
-    // fn show_text(notifier: &ToastNotifier, text: &str) -> anyhow::Result<()> {
+    // fn show_text(notifier: &ToastNotifier, text: &str) -> Result<()> {
     //     let notification = ToastNotification::new_with_text(text)?;
     //     notifier.show(&notification)
     // }
     // ```
-    pub fn new_with_text(text: &str) -> anyhow::Result<Self> {
+    pub fn new_with_text(text: &str) -> Result<Self> {
         let template = ToastTemplateType::ToastText01;
         let toast_xml = ToastNotificationManager::GetTemplateContent(template)?;
         let text_node = toast_xml.SelectSingleNode(&"//text[@id=\"1\"]".into())?;
@@ -46,7 +48,7 @@ impl NotificationImpl {
     }
 
     /// Set the expiration time to the `duration` from the current time.
-    pub fn expires_in(&mut self, duration: Duration) -> anyhow::Result<()> {
+    pub fn expires_in(&mut self, duration: Duration) -> Result<()> {
         let win_cal = Calendar::new()?;
         win_cal.AddSeconds(duration.as_secs() as i32)?;
         let dt = win_cal.GetDateTime()?;
@@ -69,13 +71,13 @@ pub struct NotifierImpl {
 }
 
 impl NotifierImpl {
-    pub fn new_with_application_id(application_id: &str) -> anyhow::Result<Self> {
+    pub fn new_with_application_id(application_id: &str) -> Result<Self> {
         let manager = ToastNotificationManager::GetDefault()?;
         let notifier = manager.CreateToastNotifierWithId(&application_id.into())?;
         Ok(Self { notifier })
     }
 
-    pub fn show(&self, notification: &NotificationImpl) -> anyhow::Result<()> {
+    pub fn show(&self, notification: &NotificationImpl) -> Result<()> {
         self.notifier.Show(&notification.notification)?;
         Ok(())
     }


### PR DESCRIPTION
This changes the public API to return the custom error instead
of `anyhow::Error`.
